### PR TITLE
US81632 - Typography audit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "neon-animation": "^1.2.4",
     "d2l-icons": "^3.0.0",
     "d2l-polymer-behaviors": "^0.0.4",
-    "d2l-colors": "^2.2.3"
+    "d2l-colors": "^2.2.3",
+    "d2l-typography": "^5.2.4"
   }
 }

--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -1,9 +1,10 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-typography/d2l-typography.html">
 
 <dom-module id="d2l-simple-overlay-styles">
 	<template>
-		<style>
+		<style include="d2l-typography">
 		:host {
 			background: white;
 			margin: 0;
@@ -26,7 +27,6 @@
 			border: none;
 			margin: 0;
 			padding: 0 0 0.2rem 0;
-			color: var(--d2l-color-ferrite);
 			cursor: pointer;
 		}
 
@@ -53,8 +53,8 @@
 		}
 
 		d2l-icon {
-			width: 12px;
-			height: 12px;
+			--iron-icon-height: 12px;
+			--iron-icon-width: 12px;
 		}
 
 		.scrollable {
@@ -75,15 +75,8 @@
 			margin-left: auto;
 			margin-right: auto;
 			max-width: 1230px;
-			@apply(--simple-overlay-content-width);
 		}
 
-		h1 {
-			/* overrides to d2l-heading-2 (h1 styled with d2l-heading-2 class) */
-			font-weight: 400;
-			font-size: 1.5rem;
-			/* end overrides */
-		}
 		@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
 			.d2l-heading-2 {
 				padding-top: 32px;

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -7,16 +7,16 @@
 <link rel="import" href="../neon-animation/animations/fade-in-animation.html">
 <link rel="import" href="../neon-animation/animations/fade-out-animation.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
-<link rel="import" href="d2l-simple-overlay-styles.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
+<link rel="import" href="d2l-simple-overlay-styles.html">
 
 <!-- This overlay supports using different animations and transitions for desktop and mobile. -->
 <dom-module id="d2l-simple-overlay">
 	<style include="d2l-simple-overlay-styles"></style>
 	<template>
-		<span role="dialog" aria-label$="[[titleName]]">
+		<span class="d2l-typography" role="dialog" aria-label$="[[titleName]]">
 			<div class="max-width container">
-				<h1 class="d2l-heading-2">{{titleName}}</h1>
+				<h2 class="d2l-heading-2">{{titleName}}</h2>
 				<button
 					class="close-button"
 					on-tap="_handleClose"


### PR DESCRIPTION
The only text within the overlay itself is just the title - it should be styled using d2l-typography. Despite it having the class previously, it wasn't actually being applied - it was just the two "overrides" that were styling it. Amusingly, those overrides are the actual values if it's applied properly. hah.

Oh, also changed the title from an `h1` to an `h2` - while there doesn't actually seem to be specific ARIA guidelines about it, examples I've found in several places show modal dialogs with non-`h1` - I'm assuming the expectation is that the page the dialog is on would be the only one that would have the `h1` heading, so a dialog should be at most `h2`.

This PR is effectively a sub-PR of https://github.com/Brightspace/d2l-my-courses-ui/pull/300.