### PR TITLE
check that event target is the overlay on transitionend

### DIFF
--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -73,7 +73,11 @@
 				e.stopPropagation();
 				this._handleClose();
 			},
-			_onTransitionEnd: function() {
+			_onTransitionEnd: function(e) {
+				if (e.target !== this) {
+					return;
+				}
+
 				if (this.opened) {
 					this._finishRenderOpened();
 				} else {


### PR DESCRIPTION
apparently transitionend bubbles, so child transitions could open/close the overlay