### PR TITLE
Remove typography import

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,9 +26,9 @@
   "dependencies": {
     "polymer": "^1.7.1",
     "iron-overlay-behavior": "^1.10.2",
-    "d2l-icons": "^3.0.0",
+    "d2l-icons": "^3.1.0",
     "d2l-polymer-behaviors": "^0.0.5",
     "d2l-colors": "^2.2.3",
-    "d2l-typography": "^5.2.4"
+    "d2l-typography": "^5.3.0"
   }
 }

--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -1,10 +1,10 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
-<link rel="import" href="../d2l-typography/d2l-typography.html">
+<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 
 <dom-module id="d2l-simple-overlay-styles">
 	<template>
-		<style include="d2l-typography">
+		<style>
 		:host {
 			background: white;
 			margin: 0;
@@ -20,6 +20,10 @@
 			-webkit-user-select: none;
 			-moz-user-select: none;
 			-ms-user-select: none;
+		}
+
+		.d2l-simple-overlay-title {
+			@apply --d2l-heading-2;
 		}
 
 		.close-button {
@@ -78,7 +82,7 @@
 		}
 
 		@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-			.d2l-heading-2 {
+			.d2l-simple-overlay-title {
 				padding-top: 32px;
 			}
 			.close-button {

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -7,11 +7,11 @@
 
 <!-- This overlay supports using different animations and transitions for desktop and mobile. -->
 <dom-module id="d2l-simple-overlay">
-	<style include="d2l-simple-overlay-styles"></style>
 	<template>
-		<span class="d2l-typography" role="dialog" aria-label$="[[titleName]]">
+		<style include="d2l-simple-overlay-styles"></style>
+		<span role="dialog" aria-label$="[[titleName]]">
 			<div class="max-width container">
-				<h2 class="d2l-heading-2">{{titleName}}</h2>
+				<h2 class="d2l-simple-overlay-title">{{titleName}}</h2>
 				<button
 					class="close-button"
 					on-tap="_handleClose"

--- a/demo/d2l-simple-overlay-demo.html
+++ b/demo/d2l-simple-overlay-demo.html
@@ -27,7 +27,7 @@
 			</script>
 			<button onclick="openOverlay()">Open Overlay!</button>
 
-			<d2l-simple-overlay id="overlay" title="Simple Overlay">
+			<d2l-simple-overlay id="overlay" title-name="Simple Overlay">
 				<p>This is the content of the simple overlay.
 				You can put any content in here.
 				Click the X to close it.</p>


### PR DESCRIPTION
This switches things to use the new Polymer mixins for headings instead of importing `d2l-typography.html` (which then imports all the font files) and relying on the CSS classes.