### PR TITLE
Allow slotted header content

### DIFF
--- a/d2l-simple-overlay-close-button-styles.html
+++ b/d2l-simple-overlay-close-button-styles.html
@@ -1,0 +1,44 @@
+<link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+
+<dom-module id="d2l-simple-overlay-close-button-styles">
+	<template>
+		<style>
+
+		.close-button {
+			background: none;
+			border: none;
+			margin: 0;
+			padding: 0 0 0.2rem 0;
+			cursor: pointer;
+		}
+
+		.close-button d2l-icon {
+			border: 1px solid transparent;
+			padding: 8px;
+		}
+
+		.close-button:focus d2l-icon, .close-button:hover d2l-icon {
+			border-radius: 0.3rem;
+			border-color: var(--d2l-color-pressicus);
+			color: var(--d2l-color-celestuba);
+		}
+
+		.close-button * {
+			box-sizing: content-box;
+		}
+
+		d2l-icon {
+			--iron-icon-height: 12px;
+			--iron-icon-width: 12px;
+		}
+
+		@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+			.close-button {
+				padding-top: 24px;
+			}
+		}
+		</style>
+	</template>
+</dom-module>

--- a/d2l-simple-overlay-close-button.html
+++ b/d2l-simple-overlay-close-button.html
@@ -1,0 +1,25 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="d2l-simple-overlay-close-button-styles.html">
+
+<dom-module id="d2l-simple-overlay-close-button">
+	<template>
+		<style include="d2l-simple-overlay-close-button-styles"></style>
+		<button
+			class="close-button"
+			on-tap="_onTap" >
+			<slot><d2l-icon icon="d2l-tier1:close-large-thick"></d2l-icon></slot>
+		</button>
+	</template>
+	<script>
+		'use strict';
+
+		Polymer({
+			is: 'd2l-simple-overlay-close-button',
+
+			_onTap: function() {
+				this.dispatchEvent(new CustomEvent('d2l-simple-overlay-close-button-clicked', { bubbles: true }));
+			}
+		});
+	</script>
+</dom-module>

--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 
 <dom-module id="d2l-simple-overlay-styles">
@@ -26,39 +25,11 @@
 			@apply --d2l-heading-2;
 		}
 
-		.close-button {
-			background: none;
-			border: none;
-			margin: 0;
-			padding: 0 0 0.2rem 0;
-			cursor: pointer;
-		}
-
 		.container {
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
 			min-height: 5.25rem;
-		}
-
-		.close-button d2l-icon {
-			border: 1px solid transparent;
-			padding: 8px;
-		}
-
-		.close-button:focus d2l-icon, .close-button:hover d2l-icon {
-			border-radius: 0.3rem;
-			border-color: var(--d2l-color-pressicus);
-			color: var(--d2l-color-celestuba);
-		}
-
-		.close-button * {
-			box-sizing: content-box;
-		}
-
-		d2l-icon {
-			--iron-icon-height: 12px;
-			--iron-icon-width: 12px;
 		}
 
 		.scrollable {
@@ -84,9 +55,6 @@
 		@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
 			.d2l-simple-overlay-title {
 				padding-top: 32px;
-			}
-			.close-button {
-				padding-top: 24px;
 			}
 		}
 

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -11,7 +11,7 @@
 	<template>
 		<style include="d2l-simple-overlay-styles"></style>
 		<span role="dialog" aria-label$="[[titleName]]">
-			<slot name="headerSlot">
+			<slot name="header">
 				<div class="max-width container">
 					<h2 class="d2l-simple-overlay-title">{{titleName}}</h2>
 					<d2l-simple-overlay-close-button

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
+<link rel="import" href="d2l-simple-overlay-close-button.html">
 
 <link rel="import" href="d2l-simple-overlay-styles.html">
 
@@ -10,19 +11,18 @@
 	<template>
 		<style include="d2l-simple-overlay-styles"></style>
 		<span role="dialog" aria-label$="[[titleName]]">
-			<div class="max-width container">
-				<h2 class="d2l-simple-overlay-title">{{titleName}}</h2>
-				<button
-					class="close-button"
-					on-tap="_handleClose"
-					aria-label$="[[closeSimpleOverlayAltText]]"
-					alt$="[[closeSimpleOverlayAltText]]">
-					<d2l-icon icon="d2l-tier1:close-large-thick"></d2l-icon>
-				</button>
-			</div>
+			<slot name="headerSlot">
+				<div class="max-width container">
+					<h2 class="d2l-simple-overlay-title">{{titleName}}</h2>
+					<d2l-simple-overlay-close-button
+						aria-label$="[[closeSimpleOverlayAltText]]"
+						alt$="[[closeSimpleOverlayAltText]]">
+					</d2l-simple-overlay-close-button>
+				</div>
+			</slot>
 			<div class="scrollable">
 				<div class="max-width">
-					<content></content>
+					<slot></slot>
 				</div>
 			</div>
 		</span>
@@ -38,7 +38,9 @@
 			],
 			listeners: {
 				'transitionend': '_onTransitionEnd',
-				'image-selector-tile-image-selected': '_handleCloseSimpleOverlayEvent'
+				'image-selector-tile-image-selected': '_handleCloseSimpleOverlayEvent',
+				'd2l-simple-overlay-close-button-clicked': '_handleClose',
+				'iron-overlay-canceled': '_handleCancel'
 			},
 			properties: {
 				// Title for overlay
@@ -62,6 +64,9 @@
 			},
 			get _focusableNodes() {
 				return [D2L.Dom.Focus.getFirstFocusableDescendant(this), D2L.Dom.Focus.getLastFocusableDescendant(this)];
+			},
+			_handleCancel: function() {
+				this.fire('d2l-simple-overlay-canceled');
 			},
 			_handleClose: function() {
 				this.close();


### PR DESCRIPTION
This is in order to support using the simple-overlay within parent portal ui, where the functionality is all very useful but the header needs to be slightly different. Consumers of this control can now either use the default header or supply their own via the `headerSlot`.

The close button has been extracted into a `d2l-simple-overlay-close-button` to allow for consumers to easily trigger a close event within the dialog within their slot template.