### PR TITLE
DE26846 - Change selector so events can properly fire again

### DIFF
--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -22,7 +22,7 @@
 			</slot>
 			<div class="scrollable">
 				<div class="max-width">
-					<slot></slot>
+					<slot id="mainContent"></slot>
 				</div>
 			</div>
 		</span>
@@ -121,7 +121,7 @@
 				return this.$$('.scrollable');
 			},
 			_notifyDistributedChildren: function(eventName) {
-				Polymer.dom(this.$$('content'))
+				Polymer.dom(this.$.mainContent)
 					.getDistributedNodes()
 					.forEach(function(childNode) {
 						this.fire(


### PR DESCRIPTION
Was just missed in #9, but the content (course images) is fetched when the event is fired.