### PR TITLE
Fixes default button content not displaying

### DIFF
--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -16,8 +16,7 @@
 						<h2 class="d2l-simple-overlay-title">{{titleName}}</h2>
 						<d2l-simple-overlay-close-button
 							aria-label$="[[closeSimpleOverlayAltText]]"
-							alt$="[[closeSimpleOverlayAltText]]">
-						</d2l-simple-overlay-close-button>
+							alt$="[[closeSimpleOverlayAltText]]"></d2l-simple-overlay-close-button>
 					</div>
 				</slot>
 			</div>

--- a/polymer.json
+++ b/polymer.json
@@ -4,7 +4,7 @@
   },
   "sources": [
     "d2l-simple-overlay-close-button-styles.html",
-    "d2l-simple-overlay-close-button-.html",
+    "d2l-simple-overlay-close-button.html",
     "d2l-simple-overlay-styles.html",
     "d2l-simple-overlay.html"
   ]


### PR DESCRIPTION
The default close button content (`<d2l-icon icon="d2l-tier1:close-large-thick"></d2l-icon>`) was not displaying. Turns out some innocuous formatting led to Polymer thinking there was content that should be overriding the default.

Also there was a little typo in polymer.json that doesn't seem to affect anything but should get fixed.