### PR TITLE
Removed dialog role

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "polymer": "^1.7.1",
-    "iron-overlay-behavior": "^1.10.2",
+    "iron-overlay-behavior": "^2.0.0",
     "d2l-icons": "^3.1.0",
     "d2l-polymer-behaviors": "^0.0.5",
     "d2l-colors": "^2.2.3",

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -9,23 +9,21 @@
 <dom-module id="d2l-simple-overlay">
 	<template>
 		<style include="d2l-simple-overlay-styles"></style>
-		<span role="dialog" aria-label$="[[titleName]]">
-			<div id="headerContainer">
-				<slot name="header">
-					<div class="max-width container">
-						<h2 class="d2l-simple-overlay-title">{{titleName}}</h2>
-						<d2l-simple-overlay-close-button
-							aria-label$="[[closeSimpleOverlayAltText]]"
-							alt$="[[closeSimpleOverlayAltText]]"></d2l-simple-overlay-close-button>
-					</div>
-				</slot>
-			</div>
-			<div class="scrollable">
-				<div id="contentContainer" class="max-width">
-					<slot id="mainSlot"></slot>
+		<div id="headerContainer">
+			<slot name="header">
+				<div class="max-width container">
+					<h2 class="d2l-simple-overlay-title">{{titleName}}</h2>
+					<d2l-simple-overlay-close-button
+						aria-label$="[[closeSimpleOverlayAltText]]"
+						alt$="[[closeSimpleOverlayAltText]]"></d2l-simple-overlay-close-button>
 				</div>
+			</slot>
+		</div>
+		<div class="scrollable">
+			<div id="contentContainer" class="max-width">
+				<slot id="mainSlot"></slot>
 			</div>
-		</span>
+		</div>
 	</template>
 	<script>
 		'use strict';


### PR DESCRIPTION
This came up when testing the accessibility of the View All Assessments overlay - I believe this wasn't noticed until now because all of the content inside the View All Courses overlay is tab accessible. I found that with this dialog role the text inside the overlay (non-focusable text) wouldn't get read out by the screen-reader. I'm not sure what exactly the dialog role is adding here that prevents it from reading text within that element.

This will require a major bump as it is semi-breaking. It will required elements that use `<d2l-simple-overlay>` to add the role and label itself: `<d2l-simple-overlay role="dialog" aria-label$="This is nonideal"`.

Opening this up to any feedback as this doesn't really seem ideal to me but I couldn't figure out another way. I've tested this on Firefox + NVDA. Tomorrow I'll further check it works with Safari + VoiceOver and Edge + JAWS

https://github.com/Brightspace/d2l-upcoming-assessments-ui/pull/36