### PR TITLE
Remove set-course-image handling

### DIFF
--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -37,7 +37,6 @@
 			],
 			listeners: {
 				'transitionend': '_onTransitionEnd',
-				'image-selector-tile-image-selected': '_handleCloseSimpleOverlayEvent',
 				'd2l-simple-overlay-close-button-clicked': '_handleClose',
 				'iron-overlay-canceled': '_handleCancel'
 			},
@@ -71,11 +70,6 @@
 				this.close();
 				this.fire('d2l-simple-overlay-closed');
 				this.fire('recalculate-columns');
-			},
-			_handleCloseSimpleOverlayEvent: function(e) {
-				e.preventDefault();
-				e.stopPropagation();
-				this._handleClose();
 			},
 			_onTransitionEnd: function(e) {
 				if (e.target !== this) {


### PR DESCRIPTION
This is a remnant from before this element and the image-selector were broken apart, and the "when a course image is selected, close the overlay" behaviour is specific to that use case. Instead, it should be up to consumers to close the overlay at the correct time, either by calling .close(), or by firing a d2l-simple-overlay-close-button-clicked event.

This is a breaking change, as it requires slightly different handling of this case in the consumers (well, consumer, only My Courses will be affected), but this can be part of the breaking change that #15 will be anyway.