### PR TITLE
Fix events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components
 bower_components-1.x
 bower-1.x.json
 node_modules/
+package-lock.json

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -43,7 +43,9 @@ Polymer-based web component for a simple overlay.  This overlay supports using d
 			listeners: {
 				'transitionend': '_onTransitionEnd',
 				'd2l-simple-overlay-close-button-clicked': '_handleClose',
-				'iron-overlay-canceled': '_handleCancel'
+				'iron-overlay-canceled': '_handleCancel',
+				'iron-overlay-opened': '_handleIronOpened',
+				'iron-overlay-closed': '_handleIronClosed'
 			},
 			properties: {
 				// Title for overlay
@@ -73,6 +75,11 @@ Polymer-based web component for a simple overlay.  This overlay supports using d
 			},
 			_handleClose: function() {
 				this.close();
+			},
+			_handleIronOpened: function() {
+				this.fire('d2l-simple-overlay-opened');
+			},
+			_handleIronClosed: function() {
 				this.fire('d2l-simple-overlay-closed');
 				this.fire('recalculate-columns');
 			},
@@ -132,6 +139,18 @@ Polymer-based web component for a simple overlay.  This overlay supports using d
 						);
 					}.bind(this));
 			}
+			/**
+			 * Fired after the overlay opens.
+			 * @event d2l-simple-overlay-opened
+			 */
+			/**
+ 			 * Fired after the overlay closes.
+ 			 * @event d2l-simple-overlay-closed
+ 			 */
+			/**
+ 			 * Fired when the overlay is cancelled, but before it is closed.
+ 			 * @event d2l-simple-overlay-cancelled
+ 			 */
 		});
 	</script>
 </dom-module>

--- a/test/d2l-simple-overlay.html
+++ b/test/d2l-simple-overlay.html
@@ -19,6 +19,17 @@
 				</d2l-simple-overlay>
 			</template>
 		</test-fixture>
+		<test-fixture id="overlay-fixture-opened">
+			<template>
+				<d2l-simple-overlay
+					title-name="Title"
+					close-simple-overlay-alt-text="close"
+					locale="en-us"
+					with-backdrop
+					opened>
+				</d2l-simple-overlay>
+			</template>
+		</test-fixture>
 
 		<script src="d2l-simple-overlay.js"></script>
 	</body>

--- a/test/d2l-simple-overlay.js
+++ b/test/d2l-simple-overlay.js
@@ -7,41 +7,79 @@ describe('d2l-simple-overlay', function() {
 		component = fixture('overlay-fixture');
 	});
 
-	it('should fire d2l-simple-overlay-closed event on closing', function(done) {
-		var handler = function() {
-			document.removeEventListener('d2l-simple-overlay-closed', handler);
-			done();
-		};
-		document.addEventListener('d2l-simple-overlay-closed', handler);
+	describe('d2l-simple-overlay-opened event', function() {
 
-		component._handleClose();
+		it('should fire d2l-simple-overlay-opened event when opened', function(done) {
+			component.addEventListener(
+				'd2l-simple-overlay-opened',
+				function handler() {
+					component.removeEventListener('d2l-simple-overlay-opened', handler);
+					done();
+				}
+			);
+			component.open();
+		});
+
+		it('should fire d2l-simple-overlay-opening event when opened', function(done) {
+			component.addEventListener(
+				'd2l-simple-overlay-opening',
+				function handler() {
+					component.removeEventListener('d2l-simple-overlay-opening', handler);
+					done();
+				}
+			);
+			component.open();
+		});
+
 	});
 
-	it('should fire recalculate-columns event on closing', function(done) {
-		var handler = function() {
-			document.removeEventListener('recalculate-columns', handler);
-			done();
-		};
-		document.addEventListener('recalculate-columns', handler);
+	describe('d2l-simple-overlay-closed event', function() {
 
-		component._handleClose();
-	});
+		beforeEach(function() {
+			component = fixture('overlay-fixture-opened');
+		});
 
-	it('should fire d2l-simple-overlay-opening event on opening', function(done) {
-		var handler = function() {
-			document.removeEventListener('d2l-simple-overlay-opening', handler);
-			done();
-		};
-		document.addEventListener('d2l-simple-overlay-opening', handler);
+		it('should fire d2l-simple-overlay-closed event when closed', function(done) {
+			component.addEventListener(
+				'd2l-simple-overlay-closed',
+				function handler() {
+					component.removeEventListener('d2l-simple-overlay-closed', handler);
+					done();
+				}
+			);
+			component.addEventListener(
+				'd2l-simple-overlay-opened',
+				function handleOpened() {
+					component.removeEventListener('d2l-simple-overlay-opened', handleOpened);
+					component.close();
+				}
+			);
+		});
 
-		component._renderOpened();
-	});
+		it('should fire recalculate-columns event when closed', function(done) {
+			component.addEventListener(
+				'recalculate-columns',
+				function handler() {
+					component.removeEventListener('recalculate-columns', handler);
+					done();
+				}
+			);
+			component.addEventListener(
+				'd2l-simple-overlay-opened',
+				function handleOpened() {
+					component.removeEventListener('d2l-simple-overlay-opened', handleOpened);
+					component.close();
+				}
+			);
+		});
 
-	it('should have a default header in the "header" slot', function() {
-		expect(component.$.headerContainer.querySelector('h2')).to.not.be.null;
 	});
 
 	describe('slot behavior', function() {
+
+		it('should have a default header in the "header" slot', function() {
+			expect(component.$.headerContainer.querySelector('h2')).to.not.be.null;
+		});
 
 		it('should allow for custom content in the "header" slot', function() {
 			var item = document.createElement('div');

--- a/test/index.html
+++ b/test/index.html
@@ -11,9 +11,8 @@
 			'use strict';
 			// Load and run all tests (.html, .js):
 			WCT.loadSuites([
-				'./d2l-simple-overlay.html?wc-shadydom=true&wc-ce=true',
-				'./d2l-simple-overlay.html?dom=shadow',
-				'./d2l-simple-overlay.html?dom=shadow&lazyRegister=true&useNativeCSSProperties=true'
+				'./d2l-simple-overlay.html?wc-shadydom=true',
+				'./d2l-simple-overlay.html?dom=shadow'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
See #17 for details.

This introduces a new `d2l-simple-overlay-opened` event that corresponds with the `iron-overlay-opened` event.

It also listens for `iron-overlay-closed` and fires `d2l-simple-overlay-closed` when it occurs so that manual calls to `.close()` fire the event.