### PR TITLE
Fix scrollable area height

### DIFF
--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -33,8 +33,8 @@
 		}
 
 		.scrollable {
-			height: calc(100vh - 100px);
-			max-height: calc(100vh - 100px);
+			height: calc(100vh - 150px);
+			max-height: calc(100vh - 150px);
 			overflow-y: auto;
 			-webkit-overflow-scrolling: touch;
 			border-top: 2px solid var(--d2l-color-gypsum);


### PR DESCRIPTION
I feel like this has probably always been here, but I guess I'd just never noticed it - if you have large (scrollable) content, the bottom of the scroll bar is currently cut off, along with the bottom few pixels of content. It seems that the header is actually 150px in height, not 100.