### PR TITLE
Stop throwing error in Edge and IE11 if detached called twice

### DIFF
--- a/d2l-simple-overlay.js
+++ b/d2l-simple-overlay.js
@@ -76,6 +76,13 @@ Polymer({
 			subtree: true
 		});
 	},
+	detached: function() {
+		if (this._observer === null) {
+			this._observer = {
+				disconnect: function() {}
+			};
+		}
+	},
 	get _focusableNodes() {
 		return [D2L.Dom.Focus.getFirstFocusableDescendant(this), D2L.Dom.Focus.getLastFocusableDescendant(this)];
 	},

--- a/test/d2l-simple-overlay.html
+++ b/test/d2l-simple-overlay.html
@@ -43,6 +43,19 @@ describe('d2l-simple-overlay', function() {
 		component = fixture('overlay-fixture');
 	});
 
+	/* iron-overlay-behavior has a bug where detached cannot be called multiple times, and this is happening on IE11 and Edge:
+	 * https://github.com/PolymerElements/iron-overlay-behavior/issues/269#issuecomment-392465251
+	 * This test confirms that our fix still works.
+	 */
+	describe('iron-overlay-behavior', function() {
+
+		it('should be able to be detached multiple times without throwing', function() {
+			component.detached();
+			component.detached();
+		});
+
+	});
+
 	describe('d2l-simple-overlay-opened event', function() {
 
 		it('should fire d2l-simple-overlay-opened event when opened', function(done) {


### PR DESCRIPTION
Since at least 10.8.11, if a user changes the widget settings of my-courses in IE11 or Edge, a console error is thrown and the cards all turn white.  A refresh fixes things.  This is happening because the widget is refreshed when the settings are changed and in polyfilled browsers, detached is being called twice (https://github.com/PolymerElements/iron-overlay-behavior/issues/269#issuecomment-392465251) and `iron-overlay-behavior` can't handle that.  This line will throw because `this._observer` is set to `null` the first run through: https://github.com/PolymerElements/iron-overlay-behavior/blob/master/iron-overlay-behavior.js#L212

One option is to fork the repo and make the detached method smarter.  Or, we can add to the detached method like done in this PR.  The behavior's `detached` will run first, and then the one here will run after.

I was tempted to lock the `iron-overlay-behavior` version, but rubrics is also using it and I think I'd need to lock it there too to avoid BSI conflicts.  Thoughts?